### PR TITLE
Updates and improvements

### DIFF
--- a/AutoLayoutKit.podspec
+++ b/AutoLayoutKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "AutoLayoutKit"
-  s.version      = "0.6.0"
+  s.version      = "0.7.0"
   s.summary      = "A descriptive way to create NSLayoutConstraints for AutoLayout in iOS 6.0+. Just use ALK to layout your views!"
   s.description  = <<-DESC
                    This Cocoa Touch framework provides a simple and intuitive 
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
                      :tag => s.version.to_s 
                    }
 
-  s.platform     = :ios, '6.0'
-  s.ios.deployment_target = '6.0'
+  s.platform     = :ios, '8.0'
+  s.ios.deployment_target = '8.0'
   s.requires_arc = true
 
   s.source_files = 'Classes'

--- a/AutoLayoutKit.podspec
+++ b/AutoLayoutKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "AutoLayoutKit"
-  s.version      = "0.7.0"
+  s.version      = "1.0.0"
   s.summary      = "A descriptive way to create NSLayoutConstraints for AutoLayout in iOS 6.0+. Just use ALK to layout your views!"
   s.description  = <<-DESC
                    This Cocoa Touch framework provides a simple and intuitive 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Increased minimum supported iOS version to 8.0 to be able to activate/deactivate constraints instead of adding/removing.
 - Each method, that affects creation of single constraint, returns newly created active constraint.
-- Introduced additinal methods which uses iOS 11 view safe areas.
+- Introduced additinal methods which uses iOS 11 view [Safe Areas]( https://developer.apple.com/documentation/uikit/uiview/positioning_content_relative_to_the_safe_area).
 - Added nullability flags to method parameters.
 - Minor optimizations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # LayoutKit CHANGELOG
 
+## 1.0.0
+
+- Increased minimum supported iOS version to 8.0 to be able to activate/deactivate constraints instead of adding/removing.
+- Each method, that affects creation of single constraint, returns newly created active constraint.
+- Introduced additinal methods which uses iOS 11 view safe areas.
+- Added nullability flags to method parameters.
+- Minor optimizations.
+
+
 ## 0.1.0
 
 Initial release.

--- a/Classes/ALKConstraints+Convenience.h
+++ b/Classes/ALKConstraints+Convenience.h
@@ -22,7 +22,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#import "ALKConstraints.h"
+#import <AutoLayoutKit/ALKConstraints.h>
 
 @interface ALKConstraints (Convenience)
 
@@ -58,7 +58,7 @@
  
  @since 0.6.0
  */
-- (void)alignAllEdgesTo:(UIView *)relatedView;
+- (void) alignAllEdgesTo:(nonnull UIView *) relatedView;
 
 /**
  @brief Aligns all edges to a given view with edge insets.
@@ -92,7 +92,7 @@
  
  @since 0.6.0
  */
-- (void)alignAllEdgesTo:(UIView *)relatedView edgeInsets:(UIEdgeInsets)insets;
+- (void) alignAllEdgesTo:(nonnull UIView *) relatedView edgeInsets:(UIEdgeInsets) insets;
 
 /**
  @brief Adds horizontal and vertical alignment to a view.
@@ -117,7 +117,7 @@
  
  @since 0.6.0
  */
-- (void)centerIn:(UIView *)relatedView;
+- (void) centerIn:(nonnull UIView *) relatedView;
 
 /**
  @brief Sets both width and height to a given size.
@@ -142,6 +142,6 @@
  
  @since 0.6.0
  */
-- (void)setSize:(CGSize)size;
+- (void) setSize:(CGSize) size;
 
 @end

--- a/Classes/ALKConstraints+Convenience.m
+++ b/Classes/ALKConstraints+Convenience.m
@@ -26,30 +26,26 @@
 
 @implementation ALKConstraints (Convenience)
 
-- (void)alignAllEdgesTo:(UIView *)relatedView
-{
+- (void) alignAllEdgesTo:(nonnull UIView *) relatedView {
   [self make:ALKLeft    equalTo:relatedView s:ALKLeft];
   [self make:ALKTop     equalTo:relatedView s:ALKTop];
   [self make:ALKRight   equalTo:relatedView s:ALKRight];
   [self make:ALKBottom  equalTo:relatedView s:ALKBottom];
 }
 
-- (void)alignAllEdgesTo:(UIView *)relatedView edgeInsets:(UIEdgeInsets)insets
-{
+- (void) alignAllEdgesTo:(nonnull UIView *) relatedView edgeInsets:(UIEdgeInsets) insets {
   [self make:ALKLeft    equalTo:relatedView s:ALKLeft     plus:insets.left];
   [self make:ALKTop     equalTo:relatedView s:ALKTop      plus:insets.top];
   [self make:ALKRight   equalTo:relatedView s:ALKRight    minus:insets.right];
   [self make:ALKBottom  equalTo:relatedView s:ALKBottom   minus:insets.bottom];
 }
 
-- (void)centerIn:(UIView *)relatedView
-{
+- (void) centerIn:(nonnull UIView *) relatedView {
   [self make:ALKCenterX  equalTo:relatedView s:ALKCenterX];
   [self make:ALKCenterY  equalTo:relatedView s:ALKCenterY];
 }
 
-- (void)setSize:(CGSize)size
-{
+- (void) setSize:(CGSize) size {
   [self set:ALKHeight to:size.height];
   [self set:ALKWidth  to:size.width];
 }

--- a/Classes/ALKConstraints.h
+++ b/Classes/ALKConstraints.h
@@ -2547,6 +2547,35 @@ typedef void (^LKLayoutBlock)(ALKConstraints * _Nonnull c);
  protocol) to which the constraint relates to.
  @param relatedAttribute The `NSLayoutAttribute on the related view that the
  constraint relates to. You need to use `ALKAttribute` names.
+ @param constant The constant is added to the multiplication result.
+ 
+ @note Added for iOS 11. Before iOS 11 uses -make:equalTo:s:times:plus:on:
+ as fallback method.
+ @note By default multiplier value is 1.
+ 
+ @see -make:equalTo:s:times:plus:on:
+ 
+ @since 1.0.0
+ */
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                      equalToSafeArea:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant;
+
+/**
+ Creates a *related* constraint on the target view meaning the constraint
+ relates to safe area of another view. This is useful for aligning view to each other, for
+ example making the center of a view equal to the center of its superview.
+ 
+ - The constraint created by this method uses the `NSLayoutRelationEqual`
+ relation.
+ 
+ @param attribute The `NSLayoutAttribute` on the target view that is influenced
+ by the created constraint. You need to use `ALKAttribute` names.
+ @param relatedItem The view (or a class implementing the `UILayoutSupport`
+ protocol) to which the constraint relates to.
+ @param relatedAttribute The `NSLayoutAttribute on the related view that the
+ constraint relates to. You need to use `ALKAttribute` names.
  @param constant The constant is subtracted from the multiplication result.
  @param name The name of the created constraint. You can fetch the created
  constraint later on using `constraintWithName:` on the `targetView`.
@@ -2564,6 +2593,35 @@ typedef void (^LKLayoutBlock)(ALKConstraints * _Nonnull c);
                                     s:(ALKAttribute) relatedAttribute
                                 minus:(CGFloat) constant
                                  name:(nullable NSString *) name;
+
+/**
+ Creates a *related* constraint on the target view meaning the constraint
+ relates to safe area of another view. This is useful for aligning view to each other, for
+ example making the center of a view equal to the center of its superview.
+ 
+ - The constraint created by this method uses the `NSLayoutRelationEqual`
+ relation.
+ 
+ @param attribute The `NSLayoutAttribute` on the target view that is influenced
+ by the created constraint. You need to use `ALKAttribute` names.
+ @param relatedItem The view (or a class implementing the `UILayoutSupport`
+ protocol) to which the constraint relates to.
+ @param relatedAttribute The `NSLayoutAttribute on the related view that the
+ constraint relates to. You need to use `ALKAttribute` names.
+ @param constant The constant is subtracted from the multiplication result.
+ 
+ @note Added for iOS 11. Before iOS 11 uses -make:equalTo:s:times:plus:on:name:
+ as fallback method.
+ @note By default multiplier value is 1.
+ 
+ @see -make:equalTo:s:times:plus:on:name:
+ 
+ @since 1.0.0
+ */
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                      equalToSafeArea:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint

--- a/Classes/ALKConstraints.h
+++ b/Classes/ALKConstraints.h
@@ -34,18 +34,18 @@
  @since 0.1.0
  */
 typedef NS_ENUM(NSInteger, ALKAttribute) {
-  /** NSLayoutAttributeLeft */            ALKLeft,
-  /** NSLayoutAttributeRight */           ALKRight,
-  /** NSLayoutAttributeTop */             ALKTop,
-  /** NSLayoutAttributeBottom */          ALKBottom,
-  /** NSLayoutAttributeLeading */         ALKLeading,
-  /** NSLayoutAttributeTrailing */        ALKTrailing,
-  /** NSLayoutAttributeWidth */           ALKWidth,
-  /** NSLayoutAttributeHeight */          ALKHeight,
-  /** NSLayoutAttributeCenterX */         ALKCenterX,
-  /** NSLayoutAttributeCenterY */         ALKCenterY,
-  /** NSLayoutAttributeBaseline */        ALKBaseline,
-  /** NSLayoutAttributeNotAnAttribute */  ALKNone
+  /** NSLayoutAttributeLeft */            ALKLeft = NSLayoutAttributeLeft,
+  /** NSLayoutAttributeRight */           ALKRight = NSLayoutAttributeRight,
+  /** NSLayoutAttributeTop */             ALKTop = NSLayoutAttributeTop,
+  /** NSLayoutAttributeBottom */          ALKBottom = NSLayoutAttributeBottom,
+  /** NSLayoutAttributeLeading */         ALKLeading = NSLayoutAttributeLeading,
+  /** NSLayoutAttributeTrailing */        ALKTrailing = NSLayoutAttributeTrailing,
+  /** NSLayoutAttributeWidth */           ALKWidth = NSLayoutAttributeWidth,
+  /** NSLayoutAttributeHeight */          ALKHeight = NSLayoutAttributeHeight,
+  /** NSLayoutAttributeCenterX */         ALKCenterX = NSLayoutAttributeCenterX,
+  /** NSLayoutAttributeCenterY */         ALKCenterY = NSLayoutAttributeCenterY,
+  /** NSLayoutAttributeBaseline */        ALKBaseline = NSLayoutAttributeBaseline,
+  /** NSLayoutAttributeNotAnAttribute */  ALKNone = NSLayoutAttributeNotAnAttribute
 };
 
 /**
@@ -56,9 +56,9 @@ typedef NS_ENUM(NSInteger, ALKAttribute) {
  @since 0.1.0
  */
 typedef NS_ENUM(NSInteger, ALKRelation) {
-  /** NSLayoutRelationLessThanOrEqual */    ALKLessThan,
-  /** NSLayoutRelationEqual */              ALKEqualTo,
-  /** NSLayoutRelationGreaterThanOrEqual */ ALKGreaterThan
+  /** NSLayoutRelationLessThanOrEqual */    ALKLessThan = NSLayoutRelationLessThanOrEqual,
+  /** NSLayoutRelationEqual */              ALKEqualTo = NSLayoutRelationEqual,
+  /** NSLayoutRelationGreaterThanOrEqual */ ALKGreaterThan = NSLayoutRelationGreaterThanOrEqual
 };
 
 /**
@@ -74,7 +74,7 @@ typedef NS_ENUM(NSInteger, ALKRelation) {
  
  @since 0.1.0
  */
-typedef void (^LKLayoutBlock)(ALKConstraints *c);
+typedef void (^LKLayoutBlock)(ALKConstraints * _Nonnull c);
 
 /**
  `ALKConstraints` is the heart of *AutoLayoutKit*. It provides the user with a
@@ -129,7 +129,7 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-+ (ALKConstraints *)layout:(UIView *)view do:(LKLayoutBlock)layoutBlock;
++ (nonnull ALKConstraints *) layout:(nonnull UIView *) view do:(nonnull LKLayoutBlock) layoutBlock;
 
 /**
  The designated initializer of `ALKConstraints`. You should never have to use 
@@ -140,7 +140,7 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (id)initWithView:(UIView *)view;
+- (nonnull instancetype) initWithView:(nonnull UIView *) view;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @name Configuring the ALKConstrain Priorities
@@ -177,7 +177,7 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)setPriority:(UILayoutPriority)priority;
+- (void) setPriority:(UILayoutPriority) priority;
 
 /**
  @brief Sets the priority of all upcoming `ALKConstraints` to 
@@ -192,7 +192,7 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)setPriorityRequired;
+- (void) setPriorityRequired;
 
 /**
  @brief Sets the priority of all upcoming `ALKConstraints` to
@@ -207,7 +207,7 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)setPriorityDefaultHigh;
+- (void) setPriorityDefaultHigh;
 
 /**
  @brief Sets the priority of all upcoming `ALKConstraints` to
@@ -222,7 +222,7 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)setPriorityDefaultLow;
+- (void) setPriorityDefaultLow;
 
 /**
  @brief Sets the priority of all upcoming `ALKConstraints` to
@@ -237,7 +237,7 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)setPriorityFittingSizeLevel;
+- (void) setPriorityFittingSizeLevel;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @name Setting Unrelated Constraints
@@ -259,8 +259,8 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)set:(ALKAttribute)attribute
-         to:(CGFloat)constant;
+- (nonnull NSLayoutConstraint *) set:(ALKAttribute) attribute
+                                  to:(CGFloat) constant;
 
 /**
  Creates an *unrelated* constraint on the target view meaning the constraint
@@ -280,9 +280,9 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)set:(ALKAttribute)attribute
-         to:(CGFloat)constant
-       name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) set:(ALKAttribute) attribute
+                                  to:(CGFloat) constant
+                                name:(nullable NSString *) name;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @name Make Equal to (Related Constraints)
@@ -313,12 +313,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        plus:(CGFloat)constant
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 plus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -345,12 +345,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-       minus:(CGFloat)constant
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                minus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -379,13 +379,13 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        plus:(CGFloat)constant
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 plus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -414,13 +414,13 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-       minus:(CGFloat)constant
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                minus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -446,11 +446,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        plus:(CGFloat)constant
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -476,11 +476,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       minus:(CGFloat)constant
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -508,12 +508,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        plus:(CGFloat)constant
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -541,12 +541,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       minus:(CGFloat)constant
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -573,11 +573,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -606,12 +606,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -637,10 +637,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -668,11 +668,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -698,11 +698,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        plus:(CGFloat)constant;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 plus:(CGFloat) constant;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -728,11 +728,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-       minus:(CGFloat)constant;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                minus:(CGFloat) constant;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -760,12 +760,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        plus:(CGFloat)constant
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 plus:(CGFloat) constant
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -793,12 +793,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-       minus:(CGFloat)constant
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                minus:(CGFloat) constant
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -823,10 +823,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        plus:(CGFloat)constant;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -851,10 +851,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       minus:(CGFloat)constant;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -881,11 +881,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        plus:(CGFloat)constant
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -912,11 +912,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       minus:(CGFloat)constant
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -942,10 +942,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -973,11 +973,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1002,9 +1002,9 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1031,10 +1031,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.1.0
  */
-- (void)make:(ALKAttribute)attribute
-     equalTo:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                              equalTo:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 name:(nullable NSString *) name;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @name Make Less Than or Equal to (Related Constraints)
@@ -1066,12 +1066,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        plus:(CGFloat)constant
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 plus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1099,12 +1099,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-       minus:(CGFloat)constant
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                minus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1134,13 +1134,13 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        plus:(CGFloat)constant
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 plus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1170,13 +1170,13 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-       minus:(CGFloat)constant
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                minus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1202,11 +1202,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        plus:(CGFloat)constant
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1232,11 +1232,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       minus:(CGFloat)constant
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1264,12 +1264,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        plus:(CGFloat)constant
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1297,12 +1297,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       minus:(CGFloat)constant
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1329,11 +1329,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1362,12 +1362,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1392,10 +1392,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1422,11 +1422,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1451,11 +1451,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        plus:(CGFloat)constant;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 plus:(CGFloat) constant;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1480,11 +1480,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-       minus:(CGFloat)constant;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                minus:(CGFloat) constant;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1511,12 +1511,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        plus:(CGFloat)constant
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 plus:(CGFloat) constant
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1543,12 +1543,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-       minus:(CGFloat)constant
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                minus:(CGFloat) constant
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1571,10 +1571,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        plus:(CGFloat)constant;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1597,10 +1597,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       minus:(CGFloat)constant;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1625,11 +1625,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        plus:(CGFloat)constant
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1654,11 +1654,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       minus:(CGFloat)constant
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+    lessThan:(nullable id) relatedItem
+           s:(ALKAttribute) relatedAttribute
+       minus:(CGFloat) constant
+        name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1682,10 +1682,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1711,11 +1711,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1738,9 +1738,9 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1764,10 +1764,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
-    lessThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                             lessThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 name:(nullable NSString *) name;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @name Make Greater Than or Equal to (Related Constraints)
@@ -1799,12 +1799,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        plus:(CGFloat)constant
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 plus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1832,12 +1832,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-       minus:(CGFloat)constant
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                minus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1867,13 +1867,13 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        plus:(CGFloat)constant
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 plus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1903,13 +1903,13 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-       minus:(CGFloat)constant
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                minus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1935,11 +1935,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        plus:(CGFloat)constant
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1965,11 +1965,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       minus:(CGFloat)constant
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -1997,12 +1997,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        plus:(CGFloat)constant
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2030,12 +2030,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       minus:(CGFloat)constant
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2062,11 +2062,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2095,12 +2095,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2125,10 +2125,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-          on:(UIView *)targetView;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                   on:(nonnull UIView *) targetView;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2155,11 +2155,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-          on:(UIView *)targetView
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                   on:(nonnull UIView *) targetView
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2184,11 +2184,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        plus:(CGFloat)constant;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 plus:(CGFloat) constant;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2213,11 +2213,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-       minus:(CGFloat)constant;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                minus:(CGFloat) constant;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2244,12 +2244,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        plus:(CGFloat)constant
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 plus:(CGFloat) constant
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2276,12 +2276,12 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-       minus:(CGFloat)constant
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                minus:(CGFloat) constant
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2304,10 +2304,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        plus:(CGFloat)constant;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2330,10 +2330,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       minus:(CGFloat)constant;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2358,11 +2358,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        plus:(CGFloat)constant
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2387,11 +2387,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.5.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       minus:(CGFloat)constant
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2415,10 +2415,10 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2444,11 +2444,11 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-       times:(CGFloat)multiplier
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                times:(CGFloat) multiplier
+                                 name:(nullable NSString *) name;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2470,9 +2470,9 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute;
 
 /**
  Creates a *related* constraint on the target view meaning the constraint
@@ -2496,10 +2496,131 @@ typedef void (^LKLayoutBlock)(ALKConstraints *c);
  
  @since 0.4.0
  */
-- (void)make:(ALKAttribute)attribute
- greaterThan:(id)relatedItem
-           s:(ALKAttribute)relatedAttribute
-        name:(NSString *)name;
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                          greaterThan:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 name:(nullable NSString *) name;
 
+/**
+ Creates a *related* constraint on the target view meaning the constraint
+ relates to safe area of another view. This is useful for aligning view to each other, for
+ example making the center of a view equal to the center of its superview.
+ 
+ - The constraint created by this method uses the `NSLayoutRelationEqual`
+ relation.
+ 
+ @param attribute The `NSLayoutAttribute` on the target view that is influenced
+ by the created constraint. You need to use `ALKAttribute` names.
+ @param relatedItem The view (or a class implementing the `UILayoutSupport`
+ protocol) to which the constraint relates to.
+ @param relatedAttribute The `NSLayoutAttribute on the related view that the
+ constraint relates to. You need to use `ALKAttribute` names.
+ @param constant The constant is added to the multiplication result.
+ @param name The name of the created constraint. You can fetch the created
+ constraint later on using `constraintWithName:` on the `targetView`.
+ 
+ @note Added for iOS 11. Before iOS 11 uses -make:equalTo:s:times:plus:on:
+ as fallback method.
+ @note By default multiplier value is 1.
+ 
+ @see -make:equalTo:s:times:plus:on:
+ 
+ @since 0.7.0
+ */
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                      equalToSafeArea:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant
+                                 name:(nullable NSString *) name;
+
+/**
+ Creates a *related* constraint on the target view meaning the constraint
+ relates to safe area of another view. This is useful for aligning view to each other, for
+ example making the center of a view equal to the center of its superview.
+ 
+ - The constraint created by this method uses the `NSLayoutRelationEqual`
+ relation.
+ 
+ @param attribute The `NSLayoutAttribute` on the target view that is influenced
+ by the created constraint. You need to use `ALKAttribute` names.
+ @param relatedItem The view (or a class implementing the `UILayoutSupport`
+ protocol) to which the constraint relates to.
+ @param relatedAttribute The `NSLayoutAttribute on the related view that the
+ constraint relates to. You need to use `ALKAttribute` names.
+ @param constant The constant is subtracted from the multiplication result.
+ @param name The name of the created constraint. You can fetch the created
+ constraint later on using `constraintWithName:` on the `targetView`.
+ 
+ @note Added for iOS 11. Before iOS 11 uses -make:equalTo:s:times:plus:on:name:
+ as fallback method.
+ @note By default multiplier value is 1.
+ 
+ @see -make:equalTo:s:times:plus:on:name:
+ 
+ @since 0.7.0
+ */
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                      equalToSafeArea:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant
+                                 name:(nullable NSString *) name;
+
+/**
+ Creates a *related* constraint on the target view meaning the constraint
+ relates to safe area of another view. This is useful for aligning view to each other, for
+ example making the center of a view equal to the center of its superview.
+ 
+ - The constraint created by this method uses the `NSLayoutRelationEqual`
+ relation.
+ 
+ @param attribute The `NSLayoutAttribute` on the target view that is influenced
+ by the created constraint. You need to use `ALKAttribute` names.
+ @param relatedItem The view (or a class implementing the `UILayoutSupport`
+ protocol) to which the constraint relates to.
+ @param relatedAttribute The `NSLayoutAttribute on the related view that the
+ constraint relates to. You need to use `ALKAttribute` names.
+ @param name The name of the created constraint. You can fetch the created
+ constraint later on using `constraintWithName:` on the `targetView`.
+ 
+ @note Added for iOS 11. Before iOS 11 uses -make:equalTo:s:times:plus:on:
+ as fallback method.
+ @note By default multiplier value is 1.
+ 
+ @see -make:equalTo:s:times:plus:on:
+ 
+ @since 0.7.0
+ */
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                      equalToSafeArea:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 name:(nullable NSString *) name;
+
+/**
+ Creates a *related* constraint on the target view meaning the constraint
+ relates to safe area of another view. This is useful for aligning view to each other, for
+ example making the center of a view equal to the center of its superview.
+ 
+ - The constraint created by this method uses the `NSLayoutRelationEqual`
+ relation.
+ 
+ @param attribute The `NSLayoutAttribute` on the target view that is influenced
+ by the created constraint. You need to use `ALKAttribute` names.
+ @param relatedItem The view (or a class implementing the `UILayoutSupport`
+ protocol) to which the constraint relates to.
+ @param relatedAttribute The `NSLayoutAttribute on the related view that the
+ constraint relates to. You need to use `ALKAttribute` names.
+ constraint later on using `constraintWithName:` on the `targetView`.
+ 
+ @note Added for iOS 11. Before iOS 11 uses -make:equalTo:s:times:plus:on:name:
+ as fallback method.
+ @note By default multiplier value is 1.
+ 
+ @see -make:equalTo:s:times:plus:on:name:
+ 
+ @since 0.7.0
+ */
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                      equalToSafeArea:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute;
 
 @end

--- a/Classes/ALKConstraints.h
+++ b/Classes/ALKConstraints.h
@@ -2525,7 +2525,7 @@ typedef void (^LKLayoutBlock)(ALKConstraints * _Nonnull c);
  
  @see -make:equalTo:s:times:plus:on:
  
- @since 0.7.0
+ @since 1.0.0
  */
 - (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
                       equalToSafeArea:(nullable id) relatedItem
@@ -2557,7 +2557,7 @@ typedef void (^LKLayoutBlock)(ALKConstraints * _Nonnull c);
  
  @see -make:equalTo:s:times:plus:on:name:
  
- @since 0.7.0
+ @since 1.0.0
  */
 - (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
                       equalToSafeArea:(nullable id) relatedItem
@@ -2588,7 +2588,7 @@ typedef void (^LKLayoutBlock)(ALKConstraints * _Nonnull c);
  
  @see -make:equalTo:s:times:plus:on:
  
- @since 0.7.0
+ @since 1.0.0
  */
 - (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
                       equalToSafeArea:(nullable id) relatedItem
@@ -2617,7 +2617,7 @@ typedef void (^LKLayoutBlock)(ALKConstraints * _Nonnull c);
  
  @see -make:equalTo:s:times:plus:on:name:
  
- @since 0.7.0
+ @since 1.0.0
  */
 - (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
                       equalToSafeArea:(nullable id) relatedItem

--- a/Classes/ALKConstraints.m
+++ b/Classes/ALKConstraints.m
@@ -27,26 +27,25 @@
 
 @interface ALKConstraints ()
 
-@property (nonatomic, strong) UIView *item;
+@property (nonatomic, strong, nonnull) UIView * item;
 @property (nonatomic, assign) UILayoutPriority priority;
 
 @end
 
 @implementation ALKConstraints
 
-+ (ALKConstraints *)layout:(UIView *)view do:(LKLayoutBlock)layoutBlock;
-{
++ (nonnull ALKConstraints *) layout:(nonnull UIView *) view do:(nonnull LKLayoutBlock) layoutBlock {
     ALKConstraints *c = [[ALKConstraints alloc] initWithView:view];
     layoutBlock(c);
     
     return c;
 }
 
-- (id)initWithView:(UIView *)view
-{
-    if (self = [super init]) {
+- (nonnull instancetype) initWithView:(nonnull UIView *) view {
+    self = [super init];
+    if (self) {
         self.item = view;
-        [self.item setTranslatesAutoresizingMaskIntoConstraints:FALSE];
+        view.translatesAutoresizingMaskIntoConstraints = NO;
         
         self.priority = UILayoutPriorityRequired;
     }
@@ -56,835 +55,823 @@
 
 #pragma mark - PRIORITY
 
-- (void)setPriorityRequired
-{
+- (void) setPriorityRequired {
     [self setPriority:UILayoutPriorityRequired];
 }
 
-- (void)setPriorityDefaultHigh
-{
+- (void) setPriorityDefaultHigh {
     [self setPriority:UILayoutPriorityDefaultHigh];
 }
 
-- (void)setPriorityDefaultLow
-{
+- (void) setPriorityDefaultLow {
     [self setPriority:UILayoutPriorityDefaultLow];
 }
 
-- (void)setPriorityFittingSizeLevel
-{
+- (void) setPriorityFittingSizeLevel {
     [self setPriority:UILayoutPriorityFittingSizeLevel];
 }
 
 #pragma mark - DSL (SET)
 
-- (void)set:(ALKAttribute)attribute to:(CGFloat)constant
-{
-    set(self.item, attribute, constant, nil, self.priority);
+- (nonnull NSLayoutConstraint *) set:(ALKAttribute) attribute to:(CGFloat) constant {
+    return set(self.item, attribute, constant, nil, self.priority);
 }
 
-- (void)set:(ALKAttribute)attribute to:(CGFloat)constant name:(NSString *)name
-{
-    set(self.item, attribute, constant, name, self.priority);
+- (nonnull NSLayoutConstraint *) set:(ALKAttribute) attribute to:(CGFloat) constant name:(nullable NSString *) name {
+    return set(self.item, attribute, constant, name, self.priority);
 }
 
 #pragma mark - DSL (MAKE)
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier plus:(CGFloat)constant on:(UIView *)targetView
-{
-    make(self.item, attribute, ALKEqualTo, relatedItem, relatedAttribute, multiplier, constant, targetView, nil, self.priority);
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier plus:(CGFloat) constant on:(nonnull UIView *) targetView {
+    return make(self.item, attribute, ALKEqualTo, relatedItem, relatedAttribute, multiplier, constant, targetView, nil, self.priority);
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier minus:(CGFloat)constant on:(UIView *)targetView
-{
-    make(self.item, attribute, ALKEqualTo, relatedItem, relatedAttribute, multiplier, ((-1) * constant), targetView, nil, self.priority);
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier minus:(CGFloat) constant on:(nonnull UIView *) targetView {
+    return make(self.item, attribute, ALKEqualTo, relatedItem, relatedAttribute, multiplier, ((-1) * constant), targetView, nil, self.priority);
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier plus:(CGFloat)constant on:(UIView *)targetView name:(NSString *)name
-{
-    make(self.item, attribute, ALKEqualTo, relatedItem, relatedAttribute, multiplier, constant, targetView, name, self.priority);
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier plus:(CGFloat) constant on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return make(self.item, attribute, ALKEqualTo, relatedItem, relatedAttribute, multiplier, constant, targetView, name, self.priority);
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier minus:(CGFloat)constant on:(UIView *)targetView name:(NSString *)name
-{
-    make(self.item, attribute, ALKEqualTo, relatedItem, relatedAttribute, multiplier, ((-1) * constant), targetView, name, self.priority);
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier minus:(CGFloat) constant on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return make(self.item, attribute, ALKEqualTo, relatedItem, relatedAttribute, multiplier, ((-1) * constant), targetView, name, self.priority);
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute plus:(CGFloat)constant on:(UIView *)targetView
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:constant
-            on:targetView];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute plus:(CGFloat) constant on:(nonnull UIView *) targetView {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:constant
+                   on:targetView];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute minus:(CGFloat)constant on:(UIView *)targetView
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:1.f
-         minus:constant
-            on:targetView];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute minus:(CGFloat) constant on:(nonnull UIView *) targetView {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                minus:constant
+                   on:targetView];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute plus:(CGFloat)constant on:(UIView *)targetView name:(NSString *)name
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:constant
-            on:targetView
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute plus:(CGFloat) constant on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:constant
+                   on:targetView
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute minus:(CGFloat)constant on:(UIView *)targetView name:(NSString *)name
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:1.f
-         minus:constant
-            on:targetView
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute minus:(CGFloat) constant on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                minus:constant
+                   on:targetView
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier on:(UIView *)targetView
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:0.f
-            on:targetView];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier on:(nonnull UIView *) targetView {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:0.f
+                   on:targetView];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier on:(UIView *)targetView name:(NSString *)name
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:0.f
-            on:targetView
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:0.f
+                   on:targetView
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute on:(UIView *)targetView
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:0.f
-            on:targetView];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute on:(nonnull UIView *) targetView {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:0.f
+                   on:targetView];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute on:(UIView *)targetView name:(NSString *)name
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:0.f
-            on:targetView
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:0.f
+                   on:targetView
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier plus:(CGFloat)constant
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:constant
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier plus:(CGFloat) constant {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:constant
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier minus:(CGFloat)constant
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:multiplier
-         minus:constant
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier minus:(CGFloat) constant {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                minus:constant
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier plus:(CGFloat)constant name:(NSString *)name
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:constant
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier plus:(CGFloat) constant name:(nullable NSString *) name {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:constant
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier minus:(CGFloat)constant name:(NSString *)name
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:multiplier
-         minus:constant
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier minus:(CGFloat) constant name:(nullable NSString *) name {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                minus:constant
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute plus:(CGFloat)constant
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:constant
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute plus:(CGFloat) constant {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:constant
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute minus:(CGFloat)constant
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:1.f
-         minus:constant
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute minus:(CGFloat) constant {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                minus:constant
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute plus:(CGFloat)constant name:(NSString *)name
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:constant
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute plus:(CGFloat) constant name:(nullable NSString *) name {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:constant
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute minus:(CGFloat)constant name:(NSString *)name
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:1.f
-         minus:constant
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute minus:(CGFloat) constant name:(nullable NSString *) name {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                minus:constant
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:0.f
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:0.f
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier name:(NSString *)name
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:0.f
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier name:(nullable NSString *) name {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:0.f
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:0.f
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:0.f
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute equalTo:(id)relatedItem s:(ALKAttribute)relatedAttribute name:(NSString *)name
-{
-    [self make:attribute
-       equalTo:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:0.f
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute equalTo:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute name:(nullable NSString *) name {
+    return [self make:attribute
+              equalTo:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:0.f
+                   on:self.item.superview
+                 name:name];
 }
 
 #pragma mark - DSL (MAKE/LESSTHAN)
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier plus:(CGFloat)constant on:(UIView *)targetView
-{
-    make(self.item, attribute, ALKLessThan, relatedItem, relatedAttribute, multiplier, constant, targetView, nil, self.priority);
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier plus:(CGFloat) constant on:(nonnull UIView *) targetView {
+    return make(self.item, attribute, ALKLessThan, relatedItem, relatedAttribute, multiplier, constant, targetView, nil, self.priority);
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier minus:(CGFloat)constant on:(UIView *)targetView
-{
-    make(self.item, attribute, ALKLessThan, relatedItem, relatedAttribute, multiplier, ((-1) * constant), targetView, nil, self.priority);
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier minus:(CGFloat) constant on:(nonnull UIView *) targetView {
+    return make(self.item, attribute, ALKLessThan, relatedItem, relatedAttribute, multiplier, ((-1) * constant), targetView, nil, self.priority);
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier plus:(CGFloat)constant on:(UIView *)targetView name:(NSString *)name
-{
-    make(self.item, attribute, ALKLessThan, relatedItem, relatedAttribute, multiplier, constant, targetView, name, self.priority);
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier plus:(CGFloat) constant on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return make(self.item, attribute, ALKLessThan, relatedItem, relatedAttribute, multiplier, constant, targetView, name, self.priority);
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier minus:(CGFloat)constant on:(UIView *)targetView name:(NSString *)name
-{
-    make(self.item, attribute, ALKLessThan, relatedItem, relatedAttribute, multiplier, ((-1) * constant), targetView, name, self.priority);
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier minus:(CGFloat) constant on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return make(self.item, attribute, ALKLessThan, relatedItem, relatedAttribute, multiplier, ((-1) * constant), targetView, name, self.priority);
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute plus:(CGFloat)constant on:(UIView *)targetView
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:constant
-            on:targetView];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute plus:(CGFloat) constant on:(nonnull UIView *) targetView {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:constant
+                   on:targetView];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute minus:(CGFloat)constant on:(UIView *)targetView
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-         minus:constant
-            on:targetView];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute minus:(CGFloat) constant on:(nonnull UIView *) targetView {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                minus:constant
+                   on:targetView];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute plus:(CGFloat)constant on:(UIView *)targetView name:(NSString *)name
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:constant
-            on:targetView
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute plus:(CGFloat) constant on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:constant
+                   on:targetView
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute minus:(CGFloat)constant on:(UIView *)targetView name:(NSString *)name
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-         minus:constant
-            on:targetView
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute minus:(CGFloat) constant on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                minus:constant
+                   on:targetView
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier on:(UIView *)targetView
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:0.f
-            on:targetView];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier on:(nonnull UIView *) targetView {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:0.f
+                   on:targetView];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier on:(UIView *)targetView name:(NSString *)name
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:0.f
-            on:targetView
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:0.f
+                   on:targetView
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute on:(UIView *)targetView
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:0.f
-            on:targetView];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute on:(nonnull UIView *) targetView {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:0.f
+                   on:targetView];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute on:(UIView *)targetView name:(NSString *)name
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:0.f
-            on:targetView
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:0.f
+                   on:targetView
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier plus:(CGFloat)constant
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:constant
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier plus:(CGFloat) constant {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:constant
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier minus:(CGFloat)constant
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-         minus:constant
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier minus:(CGFloat) constant {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                minus:constant
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier plus:(CGFloat)constant name:(NSString *)name
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:constant
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier plus:(CGFloat) constant name:(nullable NSString *) name {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:constant
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier minus:(CGFloat)constant name:(NSString *)name
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-         minus:constant
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier minus:(CGFloat) constant name:(nullable NSString *) name {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                minus:constant
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute plus:(CGFloat)constant
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:constant
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute plus:(CGFloat) constant {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:constant
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute minus:(CGFloat)constant
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-         minus:constant
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute minus:(CGFloat) constant {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                minus:constant
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute plus:(CGFloat)constant name:(NSString *)name
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:constant
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute plus:(CGFloat) constant name:(nullable NSString *) name {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:constant
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute minus:(CGFloat)constant name:(NSString *)name
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-         minus:constant
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute minus:(CGFloat) constant name:(nullable NSString *) name {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                minus:constant
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:0.f
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:0.f
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier name:(NSString *)name
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:0.f
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier name:(nullable NSString *) name {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:0.f
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:0.f
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:0.f
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute lessThan:(id)relatedItem s:(ALKAttribute)relatedAttribute name:(NSString *)name
-{
-    [self make:attribute
-      lessThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:0.f
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute lessThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute name:(nullable NSString *) name {
+    return [self make:attribute
+             lessThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:0.f
+                   on:self.item.superview
+                 name:name];
 }
 
 #pragma mark - DSL (MAKE/GREATERTHAN)
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier plus:(CGFloat)constant on:(UIView *)targetView
-{
-    make(self.item, attribute, ALKGreaterThan, relatedItem, relatedAttribute, multiplier, constant, targetView, nil, self.priority);
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier plus:(CGFloat) constant on:(nonnull UIView *) targetView {
+    return make(self.item, attribute, ALKGreaterThan, relatedItem, relatedAttribute, multiplier, constant, targetView, nil, self.priority);
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier minus:(CGFloat)constant on:(UIView *)targetView
-{
-    make(self.item, attribute, ALKGreaterThan, relatedItem, relatedAttribute, multiplier, ((-1) * constant), targetView, nil, self.priority);
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier minus:(CGFloat) constant on:(nonnull UIView *) targetView {
+    return make(self.item, attribute, ALKGreaterThan, relatedItem, relatedAttribute, multiplier, ((-1) * constant), targetView, nil, self.priority);
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier plus:(CGFloat)constant on:(UIView *)targetView name:(NSString *)name
-{
-    make(self.item, attribute, ALKGreaterThan, relatedItem, relatedAttribute, multiplier, constant, targetView, name, self.priority);
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier plus:(CGFloat) constant on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return make(self.item, attribute, ALKGreaterThan, relatedItem, relatedAttribute, multiplier, constant, targetView, name, self.priority);
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier minus:(CGFloat)constant on:(UIView *)targetView name:(NSString *)name
-{
-    make(self.item, attribute, ALKGreaterThan, relatedItem, relatedAttribute, multiplier, ((-1) * constant), targetView, name, self.priority);
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier minus:(CGFloat) constant on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return make(self.item, attribute, ALKGreaterThan, relatedItem, relatedAttribute, multiplier, ((-1) * constant), targetView, name, self.priority);
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute plus:(CGFloat)constant on:(UIView *)targetView
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:constant
-            on:targetView];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute plus:(CGFloat) constant on:(nonnull UIView *) targetView {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:constant
+                   on:targetView];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute minus:(CGFloat)constant on:(UIView *)targetView
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-         minus:constant
-            on:targetView];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute minus:(CGFloat) constant on:(nonnull UIView *) targetView {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                minus:constant
+                   on:targetView];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute plus:(CGFloat)constant on:(UIView *)targetView name:(NSString *)name
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:constant
-            on:targetView
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute plus:(CGFloat) constant on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:constant
+                   on:targetView
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute minus:(CGFloat)constant on:(UIView *)targetView name:(NSString *)name
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-         minus:constant
-            on:targetView
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute minus:(CGFloat) constant on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                minus:constant
+                   on:targetView
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier on:(UIView *)targetView
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:0.f
-            on:targetView];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier on:(nonnull UIView *) targetView {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:0.f
+                   on:targetView];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier on:(UIView *)targetView name:(NSString *)name
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:0.f
-            on:targetView
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:0.f
+                   on:targetView
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute on:(UIView *)targetView
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:0.f
-            on:targetView];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute on:(nonnull UIView *) targetView {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:0.f
+                   on:targetView];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute on:(UIView *)targetView name:(NSString *)name
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:0.f
-            on:targetView
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute on:(nonnull UIView *) targetView name:(nullable NSString *) name {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:0.f
+                   on:targetView
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier plus:(CGFloat)constant
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:constant
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier plus:(CGFloat) constant {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:constant
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier minus:(CGFloat)constant
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-         minus:constant
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier minus:(CGFloat) constant {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                minus:constant
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier plus:(CGFloat)constant name:(NSString *)name
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:constant
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier plus:(CGFloat) constant name:(nullable NSString *) name {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:constant
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier minus:(CGFloat)constant name:(NSString *)name
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-         minus:constant
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier minus:(CGFloat) constant name:(nullable NSString *) name {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                minus:constant
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute plus:(CGFloat)constant
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:constant
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute plus:(CGFloat) constant {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:constant
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute minus:(CGFloat)constant
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-         minus:constant
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute minus:(CGFloat) constant {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                minus:constant
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute plus:(CGFloat)constant name:(NSString *)name
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:constant
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute plus:(CGFloat) constant name:(nullable NSString *) name {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:constant
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute minus:(CGFloat)constant name:(NSString *)name
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-         minus:constant
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute minus:(CGFloat) constant name:(nullable NSString *) name {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                minus:constant
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:0.f
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:0.f
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute times:(CGFloat)multiplier name:(NSString *)name
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:multiplier
-          plus:0.f
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute times:(CGFloat) multiplier name:(nullable NSString *) name {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:multiplier
+                 plus:0.f
+                   on:self.item.superview
+                 name:name];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:0.f
-            on:self.item.superview];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:0.f
+                   on:self.item.superview];
 }
 
-- (void)make:(ALKAttribute)attribute greaterThan:(id)relatedItem s:(ALKAttribute)relatedAttribute name:(NSString *)name
-{
-    [self make:attribute
-   greaterThan:relatedItem
-             s:relatedAttribute
-         times:1.f
-          plus:0.f
-            on:self.item.superview
-          name:name];
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute greaterThan:(nullable id) relatedItem s:(ALKAttribute) relatedAttribute name:(nullable NSString *) name {
+    return [self make:attribute
+          greaterThan:relatedItem
+                    s:relatedAttribute
+                times:1.f
+                 plus:0.f
+                   on:self.item.superview
+                 name:name];
+}
+
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                      equalToSafeArea:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant
+                                 name:(nullable NSString *) name {
+    NSLayoutConstraint * lc = nil;
+#if defined(NSFoundationVersionNumber_iOS_9_0)
+    lc = makeSafeArea(self.item, attribute, relatedItem, relatedAttribute, constant, self.item.superview, name, self.priority);
+#endif
+    return lc ? lc : [self make:attribute equalTo:relatedItem s:relatedAttribute times:1 plus:constant name:name];
+}
+
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                      equalToSafeArea:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant
+                                 name:(nullable NSString *) name {
+    NSLayoutConstraint * lc = nil;
+#if defined(NSFoundationVersionNumber_iOS_9_0)
+    lc = makeSafeArea(self.item, attribute, relatedItem, relatedAttribute, -constant, self.item.superview, name, self.priority);
+#endif
+    return lc ? lc : [self make:attribute equalTo:relatedItem s:relatedAttribute times:1 minus:constant name:name];
+}
+
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                      equalToSafeArea:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                 name:(nullable NSString *) name {
+    NSLayoutConstraint * lc = nil;
+#if defined(NSFoundationVersionNumber_iOS_9_0)
+    lc = makeSafeArea(self.item, attribute, relatedItem, relatedAttribute, 0, self.item.superview, name, self.priority);
+#endif
+    return lc ? lc : [self make:attribute equalTo:relatedItem s:relatedAttribute times:1 plus:0 name:name];
+}
+
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                      equalToSafeArea:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute {
+    NSLayoutConstraint * lc = nil;
+#if defined(NSFoundationVersionNumber_iOS_9_0)
+    lc = makeSafeArea(self.item, attribute, relatedItem, relatedAttribute, 0, self.item.superview, nil, self.priority);
+#endif
+    return lc ? lc : [self make:attribute equalTo:relatedItem s:relatedAttribute times:1 plus:0 name:nil];
 }
 
 #pragma mark - Functions
 
-static void set (UIView *item,
-                 ALKAttribute itemAttribute,
-                 CGFloat constant,
-                 NSString *name,
-                 UILayoutPriority priority)
-{
-    createLayoutConstraint(item, itemAttribute, ALKEqualTo, nil, ALKNone, 1.f, constant, item, name, priority);
-}
+#if defined(NSFoundationVersionNumber_iOS_9_0)
 
-static void make(UIView *item,
-                 ALKAttribute itemAttribute,
-                 ALKRelation relation,
-                 id relatedItem,
-                 ALKAttribute relatedItemAttribute,
-                 CGFloat multiplier,
-                 CGFloat constant,
-                 UIView *targetItem,
-                 NSString *name,
-                 UILayoutPriority priority)
-{
-    createLayoutConstraint(item, itemAttribute, relation, relatedItem, relatedItemAttribute, multiplier, constant, targetItem, name, priority);
-}
-
-static NSLayoutConstraint * createLayoutConstraint(UIView *item,
+static NSLayoutConstraint * _Nullable makeSafeArea(UIView * _Nonnull item,
                                                    ALKAttribute itemAttribute,
-                                                   ALKRelation relation,
-                                                   id relatedItem,
+                                                   id _Nullable relatedItem,
                                                    ALKAttribute relatedItemAttribute,
-                                                   CGFloat multiplier,
                                                    CGFloat constant,
-                                                   UIView *targetItem,
-                                                   NSString *name,
-                                                   UILayoutPriority priority)
-{
-    NSLayoutAttribute itemAttributeValue = [ALKConstraints enumToAttribute:itemAttribute];
-    NSLayoutRelation relationValue = [ALKConstraints enumToRelation:relation];
-    NSLayoutAttribute relatedItemAttributeValue = [ALKConstraints enumToAttribute:relatedItemAttribute];
+                                                   UIView * _Nonnull targetItem,
+                                                   NSString * _Nullable name,
+                                                   UILayoutPriority priority) {
+    NSLayoutConstraint * lc = nil;
+    if (@available(iOS 11, *)) {
+        NSLayoutAnchor * anchor = viewLayoutAnchor(item, itemAttribute);
+        NSLayoutAnchor * relatedAnchor = relatedItem ? guideLayoutAnchor(((UIView *)relatedItem).safeAreaLayoutGuide, relatedItemAttribute) : nil;
+        lc = (anchor && relatedAnchor) ? [anchor constraintEqualToAnchor:relatedAnchor] : nil;
+        if (lc) {
+            lc.constant = constant;
+            lc.priority = priority;
+            if (name) {
+                [targetItem alk_addConstraint:lc withName:name];
+            } else {
+                lc.active = YES;
+            }
+        }
+    }
+    return lc;
+}
+
+static id _Nullable viewLayoutAnchor(UIView * _Nonnull view, ALKAttribute attribute) {
+    if (@available(iOS 9, *)) {
+        switch (attribute) {
+            case ALKLeft: return view.leftAnchor;
+            case ALKRight: return view.rightAnchor;
+            case ALKTop: return view.topAnchor;
+            case ALKBottom: return view.bottomAnchor;
+            case ALKLeading: return view.leadingAnchor;
+            case ALKTrailing: return view.trailingAnchor;
+            case ALKWidth: return view.widthAnchor;
+            case ALKHeight: return view.heightAnchor;
+            case ALKCenterX: return view.centerXAnchor;
+            case ALKCenterY: return view.centerYAnchor;
+            case ALKBaseline: return view.firstBaselineAnchor;
+            case ALKNone: return nil;
+        }
+    }
+    return nil;
+}
+
+static id _Nullable guideLayoutAnchor(id _Nonnull guide, ALKAttribute attribute) {
+    if (@available(iOS 9, *)) {
+        UILayoutGuide * layoutGuide = (UILayoutGuide *)guide;
+        switch (attribute) {
+            case ALKLeft: return layoutGuide.leftAnchor;
+            case ALKRight: return layoutGuide.rightAnchor;
+            case ALKTop: return layoutGuide.topAnchor;
+            case ALKBottom: return layoutGuide.bottomAnchor;
+            case ALKLeading: return layoutGuide.leadingAnchor;
+            case ALKTrailing: return layoutGuide.trailingAnchor;
+            case ALKWidth: return layoutGuide.widthAnchor;
+            case ALKHeight: return layoutGuide.heightAnchor;
+            case ALKCenterX: return layoutGuide.centerXAnchor;
+            case ALKCenterY: return layoutGuide.centerYAnchor;
+            case ALKBaseline:
+            case ALKNone: return nil;
+        }
+    }
+    return nil;
+}
+
+#endif
+
+static NSLayoutConstraint * _Nonnull set(UIView * _Nonnull item,
+                                         ALKAttribute itemAttribute,
+                                         CGFloat constant,
+                                         NSString * _Nullable name,
+                                         UILayoutPriority priority) {
+    return createLayoutConstraint(item, itemAttribute, ALKEqualTo, nil, ALKNone, 1.f, constant, item, name, priority);
+}
+
+static NSLayoutConstraint * _Nonnull make(UIView * _Nonnull item,
+                                          ALKAttribute itemAttribute,
+                                          ALKRelation relation,
+                                          id _Nullable relatedItem,
+                                          ALKAttribute relatedItemAttribute,
+                                          CGFloat multiplier,
+                                          CGFloat constant,
+                                          UIView * _Nonnull targetItem,
+                                          NSString * _Nullable name,
+                                          UILayoutPriority priority) {
+    return createLayoutConstraint(item, itemAttribute, relation, relatedItem, relatedItemAttribute, multiplier, constant, targetItem, name, priority);
+}
+
+static NSLayoutConstraint * _Nonnull createLayoutConstraint(UIView * _Nonnull item,
+                                                            ALKAttribute itemAttribute,
+                                                            ALKRelation relation,
+                                                            id _Nullable relatedItem,
+                                                            ALKAttribute relatedItemAttribute,
+                                                            CGFloat multiplier,
+                                                            CGFloat constant,
+                                                            UIView * _Nonnull targetItem,
+                                                            NSString * _Nullable name,
+                                                            UILayoutPriority priority) {
     
     NSLayoutConstraint *lc = [NSLayoutConstraint constraintWithItem:item
-                                                          attribute:itemAttributeValue
-                                                          relatedBy:relationValue
+                                                          attribute:(NSLayoutAttribute)itemAttribute
+                                                          relatedBy:(NSLayoutRelation)relation
                                                              toItem:relatedItem
-                                                          attribute:relatedItemAttributeValue
+                                                          attribute:(NSLayoutAttribute)relatedItemAttribute
                                                          multiplier:multiplier
                                                            constant:constant];
     
     lc.priority = priority;
     
-    if (nil != name) {
+    if (name) {
         [targetItem alk_addConstraint:lc withName:name];
     } else {
-        [targetItem addConstraint:lc];
+        lc.active = YES;
     }
     
     return lc;
-}
-
-#pragma mark - ENUM Conversion
-
-+ (NSLayoutAttribute)enumToAttribute:(ALKAttribute)attribute
-{
-    switch (attribute) {
-        case ALKLeft:
-            return NSLayoutAttributeLeft;
-        case ALKRight:
-            return NSLayoutAttributeRight;
-        case ALKTop:
-            return NSLayoutAttributeTop;
-        case ALKBottom:
-            return NSLayoutAttributeBottom;
-        case ALKLeading:
-            return NSLayoutAttributeLeading;
-        case ALKTrailing:
-            return NSLayoutAttributeTrailing;
-        case ALKWidth:
-            return NSLayoutAttributeWidth;
-        case ALKHeight:
-            return NSLayoutAttributeHeight;
-        case ALKCenterX:
-            return NSLayoutAttributeCenterX;
-        case ALKCenterY:
-            return NSLayoutAttributeCenterY;
-        case ALKBaseline:
-            return NSLayoutAttributeBaseline;
-        case ALKNone:
-            return NSLayoutAttributeNotAnAttribute;
-    }
-}
-
-+ (NSLayoutRelation)enumToRelation:(ALKRelation)relation
-{
-    switch (relation) {
-        case ALKLessThan:
-            return NSLayoutRelationLessThanOrEqual;
-        case ALKEqualTo:
-            return NSLayoutRelationEqual;
-        case ALKGreaterThan:
-            return NSLayoutRelationGreaterThanOrEqual;
-    }
 }
 
 @end

--- a/Classes/ALKConstraints.m
+++ b/Classes/ALKConstraints.m
@@ -720,6 +720,17 @@
 - (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
                       equalToSafeArea:(nullable id) relatedItem
                                     s:(ALKAttribute) relatedAttribute
+                                 plus:(CGFloat) constant {
+    NSLayoutConstraint * lc = nil;
+#if defined(NSFoundationVersionNumber_iOS_9_0)
+    lc = makeSafeArea(self.item, attribute, relatedItem, relatedAttribute, constant, self.item.superview, nil, self.priority);
+#endif
+    return lc ? lc : [self make:attribute equalTo:relatedItem s:relatedAttribute times:1 plus:constant name:nil];
+}
+
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                      equalToSafeArea:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
                                 minus:(CGFloat) constant
                                  name:(nullable NSString *) name {
     NSLayoutConstraint * lc = nil;
@@ -727,6 +738,17 @@
     lc = makeSafeArea(self.item, attribute, relatedItem, relatedAttribute, -constant, self.item.superview, name, self.priority);
 #endif
     return lc ? lc : [self make:attribute equalTo:relatedItem s:relatedAttribute times:1 minus:constant name:name];
+}
+
+- (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute
+                      equalToSafeArea:(nullable id) relatedItem
+                                    s:(ALKAttribute) relatedAttribute
+                                minus:(CGFloat) constant {
+    NSLayoutConstraint * lc = nil;
+#if defined(NSFoundationVersionNumber_iOS_9_0)
+    lc = makeSafeArea(self.item, attribute, relatedItem, relatedAttribute, -constant, self.item.superview, nil, self.priority);
+#endif
+    return lc ? lc : [self make:attribute equalTo:relatedItem s:relatedAttribute times:1 minus:constant name:nil];
 }
 
 - (nonnull NSLayoutConstraint *) make:(ALKAttribute) attribute

--- a/Classes/UIView+ALKNamedConstraints.h
+++ b/Classes/UIView+ALKNamedConstraints.h
@@ -39,7 +39,7 @@
  
  @since 0.1.0
  */
-@property (nonatomic, retain, setter = alk_setNamedConstraints:) NSMutableDictionary* alk_namedConstraints;
+@property (nonatomic, strong, nonnull, setter = alk_setNamedConstraints:) NSMutableDictionary * alk_namedConstraints;
 
 /** 
  Tries to add a constraint to the `UIView` while remembering the 
@@ -52,8 +52,8 @@
  
  @since 0.1.0
  */
-- (NSLayoutConstraint *)alk_addConstraint:(NSLayoutConstraint *)constraint
-                                 withName:(NSString *)name;
+- (nonnull NSLayoutConstraint *) alk_addConstraint:(nonnull NSLayoutConstraint *) constraint
+                                          withName:(nullable NSString *) name;
 
 /** 
  Looks in the named constraints for a constraint named `name` and returns it
@@ -66,7 +66,7 @@
  
  @since 0.1.0
  */
-- (NSLayoutConstraint *)alk_constraintWithName:(NSString *)name;
+- (nullable NSLayoutConstraint *) alk_constraintWithName:(nullable NSString *) name;
 
 /** 
  Takes an array of names and tries to remove all `NSLayoutConstraint` instances 
@@ -80,7 +80,7 @@
  
  @since 0.1.0
  */
-- (void)alk_removeConstraintsWithNames:(NSArray *)names;
+- (void) alk_removeConstraintsWithNames:(nonnull NSArray< NSString* > *) names;
 
 /** 
  Takes as single name and tries to remove the `NSLayoutConstraint` instance from 
@@ -94,6 +94,6 @@
  
  @since 0.1.0
  */
-- (void)alk_removeConstraintWithName:(NSString *)name;
+- (void) alk_removeConstraintWithName:(nullable NSString *) name;
 
 @end

--- a/Classes/UIView+ALKNamedConstraints.m
+++ b/Classes/UIView+ALKNamedConstraints.m
@@ -33,9 +33,8 @@ NSString * const kALKNamedConstraints = @"kALKNamedConstraints";
 
 #pragma mark - Public API
 
-- (NSLayoutConstraint *)alk_addConstraint:(NSLayoutConstraint *)constraint withName:(NSString *)name
-{
-    if ((nil == constraint) || (nil == name)) return FALSE;
+- (nonnull NSLayoutConstraint *) alk_addConstraint:(nonnull NSLayoutConstraint *) constraint withName:(nullable NSString *) name {
+    if ((nil == constraint) || (nil == name)) return nil;
     
     NSMutableDictionary *namedConstraints = [self alk_namedConstraints];
     
@@ -44,7 +43,7 @@ NSString * const kALKNamedConstraints = @"kALKNamedConstraints";
     
     if (nil == oldConstraint) {
         namedConstraints[name] = constraint;
-        [self addConstraint:constraint];
+        constraint.active = YES;
         return constraint;
     } else {
         NSLog(@"Layout Constraint with name \"%@\" already exists", name);
@@ -52,8 +51,7 @@ NSString * const kALKNamedConstraints = @"kALKNamedConstraints";
     }
 }
 
-- (NSLayoutConstraint *)alk_constraintWithName:(NSString *)name
-{
+- (nullable NSLayoutConstraint *) alk_constraintWithName:(nullable NSString *) name {
     if (nil == name) return nil;
     
     id obj = self.alk_namedConstraints[name];
@@ -65,8 +63,7 @@ NSString * const kALKNamedConstraints = @"kALKNamedConstraints";
     return nil;
 }
 
-- (void)alk_removeConstraintsWithNames:(NSArray *)names
-{
+- (void) alk_removeConstraintsWithNames:(nonnull NSArray< NSString* > *) names {
     for (id obj in names) {
         if ([obj isKindOfClass:[NSString class]]) {
             [self alk_removeConstraintWithName:(NSString *)obj];
@@ -74,27 +71,24 @@ NSString * const kALKNamedConstraints = @"kALKNamedConstraints";
     }
 }
 
-- (void)alk_removeConstraintWithName:(NSString *)name
-{
+- (void) alk_removeConstraintWithName:(nullable NSString *) name {
     if (nil == name) return;
     
     NSLayoutConstraint *constraint = [self alk_constraintWithName:name];
     
     if (nil != constraint) {
-        [self removeConstraint:constraint];
+        constraint.active = NO;
         [self.alk_namedConstraints removeObjectForKey:name];
     }
 }
 
 #pragma mark - Getter & Setter LK_namedConstraints
 
-- (void)alk_setNamedConstraints:(NSMutableDictionary *)namedConstraintsDict
-{
+- (void) alk_setNamedConstraints:(nonnull NSMutableDictionary *) namedConstraintsDict {
 	objc_setAssociatedObject(self, (__bridge const void *)(kALKNamedConstraints), namedConstraintsDict, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-- (NSMutableDictionary *)alk_namedConstraints
-{
+- (nonnull NSMutableDictionary *) alk_namedConstraints {
     NSMutableDictionary *namedConstraints = objc_getAssociatedObject(self, (__bridge const void *)(kALKNamedConstraints));
     
     // there is no namedConstraints dictionary yet -> create one

--- a/Example/AutoLayoutKitTests/PriorityTests.m
+++ b/Example/AutoLayoutKitTests/PriorityTests.m
@@ -152,4 +152,112 @@
                                @"");
 }
 
+- (void)testDefaultPriorityUsingBlockConstraint
+{
+  __block NSLayoutConstraint * constraint = nil;
+  [ALKConstraints layout:self.view do:^(ALKConstraints *c) {
+    constraint = [c set:ALKWidth to:100.f];
+  }];
+  
+  XCTAssertNotNil(constraint);
+  XCTAssertEqualWithAccuracy(constraint.priority,
+                             UILayoutPriorityRequired,
+                             .0001f,
+                             @"");
+}
+
+- (void)testSetPriorityExplicitUsingBlockConstraint
+{
+  __block NSLayoutConstraint * constraint = nil;
+  [ALKConstraints layout:self.view do:^(ALKConstraints *c) {
+    [c setPriority:123];
+    constraint = [c set:ALKHeight to:100.f];
+  }];
+  
+  XCTAssertNotNil(constraint);
+  XCTAssertEqualWithAccuracy(constraint.priority,
+                             123,
+                             .0001f,
+                             @"");
+}
+
+- (void)testResetPriorityUsingBlockConstraint
+{
+  __block NSLayoutConstraint * constraint = nil;
+  [ALKConstraints layout:self.view do:^(ALKConstraints *c) {
+    [c setPriority:123];
+    [c set:ALKHeight to:100.f];
+    
+    [c setPriorityRequired];
+    constraint = [c set:ALKWidth to:100.f];
+  }];
+  
+  XCTAssertNotNil(constraint);
+  XCTAssertEqualWithAccuracy(constraint.priority,
+                             UILayoutPriorityRequired,
+                             .0001f,
+                             @"");
+}
+
+- (void)testSetPriorityRequiredUsingBlockConstraint
+{
+  __block NSLayoutConstraint * constraint = nil;
+  [ALKConstraints layout:self.view do:^(ALKConstraints *c) {
+    [c setPriorityRequired];
+    constraint = [c set:ALKHeight to:100.f];
+  }];
+  
+  XCTAssertNotNil(constraint);
+  XCTAssertEqualWithAccuracy(constraint.priority,
+                             UILayoutPriorityRequired,
+                             .0001f,
+                             @"");
+}
+
+- (void)testSetPriorityDefaultHighUsingBlockConstraint
+{
+  __block NSLayoutConstraint * constraint = nil;
+  [ALKConstraints layout:self.view do:^(ALKConstraints *c) {
+    [c setPriorityDefaultHigh];
+    constraint = [c set:ALKHeight to:100.f];
+  }];
+  
+  XCTAssertNotNil(constraint);
+  XCTAssertEqualWithAccuracy(constraint.priority,
+                             UILayoutPriorityDefaultHigh,
+                             .0001f,
+                             @"");
+}
+
+- (void)testSetPriorityDefaultLowUsingBlockConstraint
+{
+  __block NSLayoutConstraint * constraint = nil;
+  [ALKConstraints layout:self.view do:^(ALKConstraints *c) {
+    [c setPriorityDefaultLow];
+    constraint = [c set:ALKHeight to:100.f];
+  }];
+  
+  XCTAssertNotNil(constraint);
+  XCTAssertEqualWithAccuracy(constraint.priority,
+                             UILayoutPriorityDefaultLow,
+                             .0001f,
+                             @"");
+}
+
+- (void)testSetPriorityFittingSizeLevelUsingBlockConstraint
+{
+  __block NSLayoutConstraint * constraint = nil;
+  [ALKConstraints layout:self.view do:^(ALKConstraints *c) {
+    [c setPriorityFittingSizeLevel];
+    constraint = [c set:ALKHeight to:100.f];
+  }];
+  
+  XCTAssertNotNil(constraint);
+  XCTAssertEqualWithAccuracy(constraint.priority,
+                             UILayoutPriorityFittingSizeLevel,
+                             .0001f,
+                             @"");
+}
+
+
 @end

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,6 +1,8 @@
-platform :ios, '6.0'
+platform :ios, '8.0'
 
-pod 'AutoLayoutKit', :path => '../'
+target :LayoutKitPrototype do
+  pod 'AutoLayoutKit', :path => '../'
+end
 
 target :AutoLayoutKitTests do
   pod 'AutoLayoutKit', :path => '../'

--- a/README.md
+++ b/README.md
@@ -39,6 +39,48 @@ Entering Version 0.6.0, the basic sample from above can be improved even further
 }];
 ```
 
+### New in Version 1.0.0:
+#### Using with Swift without optional chaining
+```Swift
+ALKConstraints.layout(titleLabel) { c in
+  c.make(.trailing, equalTo: self, s: .trailing, minus: 10)
+}
+```
+
+#### Store newly created active constraint to block valiable
+```Objective-C
+__block NSLayoutConstraint * heightConstraint = nil;
+[ALKConstraints layout:self.view do:^(ALKConstraints * c) {
+  heightConstraint = [c set:ALKHeight to:100.f];
+}];
+```
+```Swift
+var leadingConstraint: NSLayoutConstraint? = nil
+ALKConstraints.layout(titleLabel) { c in
+  leadingConstraint = c.make(.leading, equalTo: self, s: .leading, plus: 10)
+}
+```
+
+#### Using iOS 11 [Safe Area](https://developer.apple.com/documentation/uikit/uiview/positioning_content_relative_to_the_safe_area)
+
+> In case of iOS version less than 11, default `make...` methods will be used as fallback.
+
+> All [Safe Area](https://developer.apple.com/documentation/uikit/uiview/positioning_content_relative_to_the_safe_area) methods uses times value as 1.0.
+
+```Objective-C
+[ALKConstraints layout:titleLabel do:^(ALKConstraints * c) {
+  [c make:ALKLeading equalToSafeArea:self.view s:ALKLeading plus:8];
+  [c make:ALKTrailing equalToSafeArea:self.view s:ALKTrailing minus:8];
+}];
+```
+```Swift
+ALKConstraints.layout(titleLabel) { c in
+  c.make(.leading, equalToSafeArea: self, s: .leading, plus: 8)
+  c.make(.trailing, equalToSafeArea: self, s: .trailing, minus: 8)
+}
+```
+
+
 ## Requirements
 
 ## Installation


### PR DESCRIPTION
- Added nullability flags to method parameters. Can be used with Swift without unused optional chaining
- Latest syntax
- Latest constraints activation/deactivation method instead of deprecated one (iOS 8 and up)
- Removed attributes mapping
- All methods returns created constraint. Can be stored directly to the block variable for future manipulations.
- Introduced methods to constraint view to it's safe areas (iOS 11)